### PR TITLE
Changes to how the topic and messagePayload finding works plus some bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ In order to use the library, a configuration of MQTT protocol has to be supplied
 ### Sending Messages
 In order to send a MQTT message, please use a BPMN throwing message event and provide `${mqttThrowingEvent}` as delegateExpression property value. In addition, the MQTT client need the information about the target topic and the message payload. There are two ways to specify those:
 #### Using event name and process variable 
-You must name the BPMN throwing message event with the topic name (without prefix) and the process execution must contain a variable called `<topic name>.payload`. 
+You must name the BPMN throwing message-definiton event with the topic name (without prefix) and the process execution must contain a variable called `<event-id>.payload`. 
 
 E.g if the prefix is configured to be `camunda-bridge`
 
 
-	<bpmn:intermediateThrowEvent id="Message_0sdfsf" name="foo/bar/zoo" />
-will lead to a message deliver to the topic `camunda-bridge/foo/bar/zoo` with the value taken from the process variable `foo/bar/zoo.payload`.
+	<bpmn:intermediateThrowEvent id="messageEventBar" name="foo/bar/zoo" />
+will lead to a message deliver to the topic `camunda-bridge/foo/bar/zoo` with the value taken from the process variable `messageEventBar.payload`.
 
 #### Using Camunda Fields extension
 As an alternative you can use the Camunda Fields extensions (see below)

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ In order to use the library, a configuration of MQTT protocol has to be supplied
 ### Sending Messages
 In order to send a MQTT message, please use a BPMN throwing message event and provide `${mqttThrowingEvent}` as delegateExpression property value. In addition, the MQTT client need the information about the target topic and the message payload. There are two ways to specify those:
 #### Using event name and process variable 
-You must name the BPMN throwing message-definiton event with the topic name (without prefix) and the process execution must contain a variable called `<event-id>.payload`. 
+You must name the BPMN throwing message-definiton event with the topic name (without prefix) and the process execution must contain a variable called `<event-id>_payload`. 
 
 E.g if the prefix is configured to be `camunda-bridge`
 
 
 	<bpmn:intermediateThrowEvent id="messageEventBar" name="foo/bar/zoo" />
-will lead to a message deliver to the topic `camunda-bridge/foo/bar/zoo` with the value taken from the process variable `messageEventBar.payload`.
+will lead to a message deliver to the topic `camunda-bridge/foo/bar/zoo` with the value taken from the process variable `messageEventBar_payload`.
 
 #### Using Camunda Fields extension
 As an alternative you can use the Camunda Fields extensions (see below)
@@ -58,9 +58,9 @@ In order to convert an incomming MQTT message to a BPMN Signal, the property `mq
 - topic: `camunda-bridge/foo/bar/zoo`
 - fired BPMN signals: `zoo`, `bar/zoo`, `foo/bar/zoo`
 - payload variables:
-  - `zoo.payload` and `zoo.topic` for process instance triggered by the signal `zoo`
-  - `bar/zoo.payload` and `bar/zoo.topic` for process instance triggered by the signal `bar/zoo`
-  - `foo/bar/zoo.payload` and `foo/bar/zoo.topic` for process instance triggered by the signal `foo/bar/zoo`
+  - `zoo_payload` and `zoo_topic` for process instance triggered by the signal `zoo`
+  - `bar/zoo_payload` and `bar/zoo_topic` for process instance triggered by the signal `bar/zoo`
+  - `foo/bar/zoo_payload` and `foo/bar/zoo_topic` for process instance triggered by the signal `foo/bar/zoo`
 
 You can suppress delivery of sub-signals (`zoo` and `bar/zoo`) by setting the property `mqtt.subsignals.supress` to `true`. 
 

--- a/mqtt-camunda-bridge/pom.xml
+++ b/mqtt-camunda-bridge/pom.xml
@@ -24,6 +24,29 @@
 			<artifactId>camunda-engine</artifactId>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.camunda.spin</groupId>
+			<artifactId>camunda-spin-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.camunda.spin</groupId>
+			<artifactId>camunda-spin-dataformat-json-jackson</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.camunda.spin</groupId>
+			<artifactId>camunda-spin-dataformat-xml-dom</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.camunda.bpm</groupId>
+			<artifactId>camunda-engine-plugin-spin</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+
 		<dependency>
 			<!-- Java EE 6 APIs -->
 			<groupId>javax</groupId>

--- a/mqtt-camunda-bridge/pom.xml
+++ b/mqtt-camunda-bridge/pom.xml
@@ -31,30 +31,36 @@
 			<version>7.0</version>
 			<scope>provided</scope>
 		</dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>provided</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
+			<scope>provided</scope>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>test</scope>
-    </dependency>
-		
 		<dependency>
-		  <groupId>org.jglue.cdi-unit</groupId>
-		  <artifactId>cdi-unit</artifactId>
-		  <version>3.1.2</version>
-		  <scope>test</scope>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jglue.cdi-unit</groupId>
+			<artifactId>cdi-unit</artifactId>
+			<version>3.1.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.1</version>
 		</dependency>
 	</dependencies>
 

--- a/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/CatchingSignalEventReceiver.java
+++ b/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/CatchingSignalEventReceiver.java
@@ -12,6 +12,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.spin.plugin.variable.SpinValues;
+import org.camunda.spin.plugin.variable.value.JsonValue;
+import org.camunda.spin.plugin.variable.value.builder.JsonValueBuilder;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,9 +80,21 @@ public class CatchingSignalEventReceiver extends MqttCallbackAdapter {
      */
     public Map<String, Object> createPayload(final String signalTopic, final String topic, final String payload) {
         final Map<String, Object> values = new HashMap<String, Object>();
-        values.put(String.format(PAYLOAD_PATTERN, signalTopic), payload);
+        values.put(String.format(PAYLOAD_PATTERN, signalTopic), convertPayload(payload));
         values.put(String.format(TOPIC_PATTERN, signalTopic), topic);
         return values;
+    }
+
+    /**
+     * Converts the payload to a Camunda JSON Object.
+     * @param payload the raw payload string.
+     * @return a Camunda JSON Object.
+     */
+    public Object convertPayload(final String payload) {
+        JsonValueBuilder b = SpinValues.jsonValue(payload);
+        ;
+        final JsonValue jsonValue = b.create();
+        return jsonValue;
     }
 
     /**

--- a/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/CatchingSignalEventReceiver.java
+++ b/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/CatchingSignalEventReceiver.java
@@ -33,11 +33,11 @@ public class CatchingSignalEventReceiver extends MqttCallbackAdapter {
     /**
      * Variable name suffix of the stored MQTT message payload.
      */
-    public static final String PAYLOAD_PATTERN = "%s.payload";
+    public static final String PAYLOAD_PATTERN = "%s_payload";
     /**
      * Variable name suffix of the stored MQTT message topic.
      */
-    public static final String TOPIC_PATTERN = "%s.topic";
+    public static final String TOPIC_PATTERN = "%s_topic";
     private static final Logger LOGGER = LoggerFactory.getLogger(CatchingSignalEventReceiver.class);
 
     @Inject

--- a/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
+++ b/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
@@ -3,9 +3,12 @@ package de.techjava.mqtt.camunda.bpm;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.model.bpmn.instance.IntermediateThrowEvent;
+import org.camunda.bpm.model.bpmn.instance.MessageEventDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,11 +35,25 @@ public class MqttThrowingEvent implements JavaDelegate {
 
     @Override
     public void execute(DelegateExecution execution) throws Exception {
-        final String topicValue = (String) topic.getValue(execution);
-        final Object messageValue = message.getValue(execution);
+        String topicValue = (String) topic.getValue(execution);
+        
+        if (topicValue==null){
+            // Try to get the topic from the message name including pattern replacement.
+            String topicPattern = getMessageName(execution);
+            topicValue = replaceVariables(execution, topicPattern);
+        }
+        
         if (topicValue == null) {
             LOGGER.warn("Not throwing any event. Topic is not specified in {}", execution.getCurrentActivityName());
         }
+
+        Object messageValue = message.getValue(execution);
+        if (messageValue == null){
+            // Resolve the messageValue from process variable {event.id}.payload.
+            final String eventId = execution.getCurrentActivityId();
+            messageValue = String.valueOf(execution.getVariable(eventId + ".payload"));
+        }
+        
         if (messageValue != null) {
             sender.sendMessage(topicValue, messageValue.toString());
             LOGGER.info("Throwing event topic {} with value {}", topicValue, messageValue);
@@ -61,4 +78,28 @@ public class MqttThrowingEvent implements JavaDelegate {
         this.message = message;
     }
 
+    
+    public static String replaceVariables(DelegateExecution execution, String topicPattern) {
+
+        if (topicPattern.contains("${")) {
+            StrSubstitutor substitutor = new StrSubstitutor(execution.getVariables());
+            return substitutor.replace(topicPattern);
+        } else {
+            return topicPattern;
+        }
+
+    }
+
+    public static String getMessageName(DelegateExecution execution) {
+        try {
+            IntermediateThrowEvent event = (IntermediateThrowEvent)execution.getBpmnModelElementInstance();
+            MessageEventDefinition definition = (MessageEventDefinition)event.getEventDefinitions().iterator().next();
+            String topicPattern = definition.getMessage().getName();
+            return topicPattern;
+        } catch (Exception e) {
+            LOGGER.info("Cannot get the Message Name.", e);
+            return null;
+        }
+    }
+    
 }

--- a/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
+++ b/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
@@ -25,7 +25,7 @@ public class MqttThrowingEvent implements JavaDelegate {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MqttThrowingEvent.class);
 
-    public static final String PAYLOAD_PATTERN = "%s.payload";
+    public static final String PAYLOAD_PATTERN = "%s_payload";
 
     @Inject
     private MqttSender sender;

--- a/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
+++ b/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
@@ -7,8 +7,10 @@ import org.apache.commons.lang3.text.StrSubstitutor;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.model.bpmn.impl.instance.EndEventImpl;
 import org.camunda.bpm.model.bpmn.instance.IntermediateThrowEvent;
 import org.camunda.bpm.model.bpmn.instance.MessageEventDefinition;
+import org.camunda.bpm.model.bpmn.instance.ThrowEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +126,7 @@ public class MqttThrowingEvent implements JavaDelegate {
 
     public static String getMessageName(DelegateExecution execution) {
         try {
-            IntermediateThrowEvent event = (IntermediateThrowEvent)execution.getBpmnModelElementInstance();
+            ThrowEvent event =(ThrowEvent) execution.getBpmnModelElementInstance();
             MessageEventDefinition definition = (MessageEventDefinition)event.getEventDefinitions().iterator().next();
             String topicPattern = definition.getMessage().getName();
             return topicPattern;

--- a/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
+++ b/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
@@ -7,8 +7,6 @@ import org.apache.commons.lang3.text.StrSubstitutor;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
-import org.camunda.bpm.model.bpmn.impl.instance.EndEventImpl;
-import org.camunda.bpm.model.bpmn.instance.IntermediateThrowEvent;
 import org.camunda.bpm.model.bpmn.instance.MessageEventDefinition;
 import org.camunda.bpm.model.bpmn.instance.ThrowEvent;
 import org.slf4j.Logger;

--- a/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
+++ b/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/bpm/MqttThrowingEvent.java
@@ -61,14 +61,17 @@ public class MqttThrowingEvent implements JavaDelegate {
      * @return the topic - if null, no message will be sent.
      */
     protected String getTopic(DelegateExecution execution) {
-        String topicValue = (String)topic.getValue(execution);
+        String topicValue = null;
+        if (topic != null) {
+            topicValue = (String)topic.getValue(execution);
+        }
 
         if (topicValue == null) {
             // Try to get the topic from the message name including pattern replacement.
             String topicPattern = getMessageName(execution);
             topicValue = replaceVariables(execution, topicPattern);
         }
-        
+
         return topicValue;
     }
 
@@ -78,14 +81,17 @@ public class MqttThrowingEvent implements JavaDelegate {
      * @return the payload - if null, no message will be sent.
      */
     protected Object getMessagePayload(DelegateExecution execution) {
-        Object messageValue = message.getValue(execution);
+        Object messageValue = null;
+        if (message != null) {
+            messageValue = message.getValue(execution);
+        }
 
         if (messageValue == null) {
             // Resolve the messageValue from process variable {event.id}.payload.
             final String variableName = String.format(PAYLOAD_PATTERN, execution.getCurrentActivityId());
             messageValue = String.valueOf(execution.getVariable(variableName));
         }
-        
+
         return messageValue;
     }
 

--- a/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/comm/MqttReceiver.java
+++ b/mqtt-camunda-bridge/src/main/java/de/techjava/mqtt/camunda/comm/MqttReceiver.java
@@ -59,7 +59,7 @@ public class MqttReceiver extends MqttCallbackAdapter {
         if (this.deliverSignals == null) {
             this.deliverSignals = Boolean.FALSE;
             logger.warn("MQTT BPMN signal delivery is deactivated. "
-                    + "Set mqtt.topic.prefix=true if you want to activate it or set it to false to avoid this message.");
+                    + "Set mqtt.signals.deliver=true if you want to activate it or set it to false to avoid this message.");
         }
         if (this.client.isConnected()) {
             this.client.setCallback(this);

--- a/mqtt-camunda-bridge/src/main/resources/environment.properties
+++ b/mqtt-camunda-bridge/src/main/resources/environment.properties
@@ -1,4 +1,4 @@
 mqtt.broker=tcp://localhost:1883
 mqtt.qos=2
-mqtt.topic.prefix=camunda-bridge
+mqtt.topic.prefix=camunda-bridge/
 mqtt.deliversignals=true


### PR DESCRIPTION
- The topic is now resolved using the name of the message-definition.
-  The payload is now resolved as <id-of-message>_payload process variable.

Fixed some NPEs.
No more dots in process variables - the script engine thinks this means propery-of.
